### PR TITLE
Use pyunifi, better critical/warning handling

### DIFF
--- a/check_unifi
+++ b/check_unifi
@@ -50,10 +50,10 @@ parser.add_argument(
     '-s', '--siteid', default='default',
     help='the site ID, UniFi >=3.x only (default "default")')
 parser.add_argument(
-    '-w', '--warning', default='0', type=int,
+    '-w', '--warning',type=int,
     help='amount of APs to be down for WARNING (default: none)')
 parser.add_argument(
-    '-c', '--critical', default='0', type=int,
+    '-c', '--critical', type=int,
     help='amount of APs to be down for CRITICAL (default: none)')
 parser.add_argument(
     '-a', '--ap', default='',
@@ -124,10 +124,10 @@ else:
                % (ap_offline, offline_list, ap_online))
     message_code = OK
 
-    if args.critical != '':
+    if args.critical is not None:
         if ap_offline >= args.critical:
             message_code = CRITICAL
-    if message_code == OK and args.warning != '':
+    if message_code == OK and args.warning is not None:
         if ap_offline >= args.warning:
             message_code = WARNING
 

--- a/check_unifi
+++ b/check_unifi
@@ -9,7 +9,7 @@
 
 import argparse
 import sys
-from unifi.controller import Controller
+from pyunifi.controller import Controller
 
 """Nagios plugin to check the UniFi Controller for AP status."""
 
@@ -50,20 +50,25 @@ parser.add_argument(
     '-s', '--siteid', default='default',
     help='the site ID, UniFi >=3.x only (default "default")')
 parser.add_argument(
-    '-w', '--warning', default='',
+    '-w', '--warning', default='0', type=int,
     help='amount of APs to be down for WARNING (default: none)')
 parser.add_argument(
-    '-c', '--critical', default='',
+    '-c', '--critical', default='0', type=int,
     help='amount of APs to be down for CRITICAL (default: none)')
 parser.add_argument(
     '-a', '--ap', default='',
     help='name of AP to get status of (default: overall check)')
+parser.add_argument(
+    '-S', '--no_ssl_verify', default=True,
+    action='store_false', dest='ssl_verify',
+    help='whether to verify SSL cert (default: true)')
 args = parser.parse_args()
+
 
 # Connect to the AP (if we can)
 try:
     c = Controller(args.hostname, args.username, args.password,
-                   args.port, args.version, args.siteid)
+                   args.port, args.version, args.siteid, args.ssl_verify)
 except Exception as e:
     print ("UNKNOWN: Error connecting to UniFi Controller (%s)|"
            "Online=0 Offline=0" % e)


### PR DESCRIPTION
This is what was suggested in issue #6, - using the maintained PyUnifi instead of the old Unifi API which is not maintained and appears not to work against more modern controllers fixes issue #5 

It also includes the fix from @kleinundzusammen 's PR #2, making the critical and warning thresholds work sensibly - with an improvement so that they behave as you'd expect if you omit them (e.g. if you use `-c1` and no `-w`, then you'll get `CRITICAL` if one or more APs is down, and `OK` otherwise - without my tweaks, you'd still get a `WARNING`.

These two changes make check_unifi work well for me against my just-upgraded 5.5.20 Unifi controller.